### PR TITLE
Added minimum prerequisite for macOS

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,6 +15,15 @@ In order to run all example in this repository you need to have
   - Go
     - [Go programming language](https://golang.org/doc/install)
     - `go` command
+    
+- macOS
+  - C Family Languages
+    - `clang` - Xcode shipped with clang compiler for C, C++, Objective-C, and Swift for free.
+    - Xcode required for most macOS development tools to run.
+  - Go
+    - `go` command
+  
+  macOS setup tutorial for development in various tools can be found in [macOS Setup - Sourabh Bajaj](http://sourabhbajaj.com/mac-setup/).
 
 ## Table of Contents
 

--- a/README.md
+++ b/README.md
@@ -17,6 +17,8 @@ In order to run all example in this repository you need to have
     - `go` command
     
 - macOS
+  - General
+    - `brew` command - Brew or Homebrew calls itself The missing package manager for macOS and is an essential tool for any developer.
   - C Family Languages
     - `clang` - Xcode shipped with clang compiler for C, C++, Objective-C, and Swift for free.
     - Xcode required for most macOS development tools to run.


### PR DESCRIPTION
The prerequisite for macOS is quite straightforward. Once developer has Xcode and Homebrew in their mac, they can install any tool in single command. Xcode is a must although not working with iOS.